### PR TITLE
sack loot_tables

### DIFF
--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_black.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_black.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_black"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_black"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_blue.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_blue.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_blue"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_blue"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_brown.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_brown.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_brown"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_brown"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_cyan.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_cyan.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_cyan"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_cyan"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_gray.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_gray.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_gray"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_gray"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_green.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_green.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_green"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_green"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_light_blue.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_light_blue.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_light_blue"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_light_blue"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_light_gray.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_light_gray.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_light_gray"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_light_gray"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_lime.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_lime.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_lime"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_lime"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_magenta.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_magenta.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_magenta"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_magenta"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_orange.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_orange.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_orange"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_orange"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_pink.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_pink.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_pink"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_pink"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_purple.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_purple.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_purple"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_purple"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_red.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_red.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_red"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_red"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_white.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_white.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_white"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_white"
 }

--- a/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_yellow.json
+++ b/common/src/main/resources/data/suppsquared/loot_table/blocks/sack_yellow.json
@@ -2,51 +2,27 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
       "bonus_rolls": 0.0,
       "entries": [
         {
           "type": "minecraft:item",
           "functions": [
             {
-              "function": "minecraft:copy_name",
+              "function": "minecraft:copy_components",
+              "include": [
+                "minecraft:custom_name",
+                "minecraft:container",
+                "minecraft:lock",
+                "minecraft:container_loot"
+              ],
               "source": "block_entity"
-            },
-            {
-              "function": "minecraft:copy_nbt",
-              "source": "block_entity",
-              "ops": [
-                {
-                  "source": "Lock",
-                  "target": "BlockEntityTag.Lock",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTable",
-                  "target": "BlockEntityTag.LootTable",
-                  "op": "replace"
-                },
-                {
-                  "source": "LootTableSeed",
-                  "target": "BlockEntityTag.LootTableSeed",
-                  "op": "replace"
-                }
-              ]
-            },
-            {
-              "function": "minecraft:set_contents",
-              "type": "minecraft:shulker_box",
-              "entries": [
-                {
-                  "type": "minecraft:dynamic",
-                  "name": "minecraft:contents"
-                }
-              ]
             }
           ],
           "name": "suppsquared:sack_yellow"
         }
-      ]
+      ],
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "suppsquared:blocks/sack_yellow"
 }


### PR DESCRIPTION
fix sack loot_tables using component_copy instead of nbt_copy for 1.21+