### PR TITLE
Fix Gold Ender Candle Holder recipe

### DIFF
--- a/common/src/main/resources/data/suppsquared/recipes/candle_holders/gold_candle_holder_ender.json
+++ b/common/src/main/resources/data/suppsquared/recipes/candle_holders/gold_candle_holder_ender.json
@@ -9,7 +9,7 @@
       "item": "buzzier_bees:ender_candle"
     },
     "2": {
-      "item": "minecraft:iron_ingot"
+      "item": "minecraft:gold_ingot"
     }
   },
   "result": {


### PR DESCRIPTION
The recipe for Gold Ender Candle Holder was using Iron Ingots rather than Gold