### PR TITLE
Fix Gold Cupric Candle Holder recipe

### DIFF
--- a/common/src/main/resources/data/suppsquared/recipes/candle_holders/gold_candle_holder_cupric.json
+++ b/common/src/main/resources/data/suppsquared/recipes/candle_holders/gold_candle_holder_cupric.json
@@ -9,11 +9,11 @@
       "item": "buzzier_bees:cupric_candle"
     },
     "2": {
-      "item": "minecraft:iron_ingot"
+      "item": "minecraft:gold_ingot"
     }
   },
   "result": {
-    "item": "suppsquared:gold_candle_holder_ender",
+    "item": "suppsquared:gold_candle_holder_cupric",
     "count": 1
   },
   "conditions": [


### PR DESCRIPTION
The recipe for Gold Cupric Candle Holder was using Iron Ingots rather than Gold, and the output was incorrectly Gold Ender Candle Holder (closes #38)