### PR TITLE
Update namespaces in candle_holders.json

### DIFF
--- a/common/src/main/resources/data/supplementaries/tags/items/candle_holders.json
+++ b/common/src/main/resources/data/supplementaries/tags/items/candle_holders.json
@@ -18,11 +18,9 @@
     "suppsquared:gold_candle_holder_magenta",
     "suppsquared:gold_candle_holder_purple",
     "suppsquared:gold_candle_holder_orange",
-    {"id":"supplementaries:gold_candle_holder_soul","required":false},
-    {"id":"supplementaries:gold_candle_holder_ender","required":false},
-    {"id":"supplementaries:gold_candle_holder_cupric","required":false},
-    {"id":"supplementaries:gold_candle_holder_spectacle","required":false}
+    {"id":"suppsquared:gold_candle_holder_soul","required":false},
+    {"id":"suppsquared:gold_candle_holder_ender","required":false},
+    {"id":"suppsquared:gold_candle_holder_cupric","required":false},
+    {"id":"suppsquared:gold_candle_holder_spectacle","required":false}
   ]
 }
-
-


### PR DESCRIPTION
Namespace for certain Gold Candle Holders was incorrectly `supplementaries` rather than `suppsquared`